### PR TITLE
Add towers, projectiles and targeting logic

### DIFF
--- a/src/core/balance.ts
+++ b/src/core/balance.ts
@@ -5,3 +5,10 @@ export const ENEMIES_PER_WAVE = 5;
 export const ENEMY_SPEED = 60; // pixels per second
 export const ENEMY_HP = 1;
 export const ENEMY_REWARD = 5;
+
+export const TOWER_COST = 20;
+export const TOWER_RANGE = 100;
+export const TOWER_FIRE_RATE = 1; // shots per second
+
+export const PROJECTILE_SPEED = 300; // pixels per second
+export const PROJECTILE_DAMAGE = 1;

--- a/src/core/grid.test.ts
+++ b/src/core/grid.test.ts
@@ -6,6 +6,10 @@ describe('grid utils', () => {
     expect(worldToGrid(64, 96)).toEqual({ col: 2, row: 3 });
   });
 
+  it('converts world coordinates with custom tile size', () => {
+    expect(worldToGrid(45, 45, 15)).toEqual({ col: 3, row: 3 });
+  });
+
   it('converts grid coordinates to world', () => {
     expect(gridToWorld(2, 3)).toEqual({ x: 64, y: 96 });
   });

--- a/src/core/targeting.test.ts
+++ b/src/core/targeting.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { selectTarget, Targetable } from './targeting';
+
+describe('target selection', () => {
+  it('selects enemy with highest progress within range', () => {
+    const enemies: Targetable[] = [
+      { x: 0, y: 0, progress: 0.1 },
+      { x: 10, y: 0, progress: 0.2 },
+      { x: 50, y: 0, progress: 0.9 },
+    ];
+    const target = selectTarget(enemies, 0, 0, 30);
+    expect(target).toEqual(enemies[1]);
+  });
+
+  it('returns undefined when no enemies in range', () => {
+    const enemies: Targetable[] = [{ x: 100, y: 100, progress: 0.9 }];
+    const target = selectTarget(enemies, 0, 0, 30);
+    expect(target).toBeUndefined();
+  });
+});

--- a/src/core/targeting.ts
+++ b/src/core/targeting.ts
@@ -1,0 +1,25 @@
+export interface Targetable {
+  x: number;
+  y: number;
+  progress: number;
+}
+
+export function selectTarget(
+  enemies: Targetable[],
+  x: number,
+  y: number,
+  range: number,
+): Targetable | undefined {
+  let best: Targetable | undefined;
+  let bestProgress = -Infinity;
+  const rangeSq = range * range;
+  for (const enemy of enemies) {
+    const dx = enemy.x - x;
+    const dy = enemy.y - y;
+    if (dx * dx + dy * dy <= rangeSq && enemy.progress > bestProgress) {
+      best = enemy;
+      bestProgress = enemy.progress;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary
- add tower and projectile classes with targeting logic and placement preview
- show range circle, pause and speed controls
- add unit tests for grid conversions and target selection

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689679966f5c8322ace9c7ecccc6db8c