### PR TITLE
perf: pooling + update batching

### DIFF
--- a/src/core/pool.test.ts
+++ b/src/core/pool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectPool } from './pool';
+
+class Dummy {
+  value = 0;
+}
+
+describe('ObjectPool', () => {
+  it('acquires and releases objects', () => {
+    const pool = new ObjectPool(
+      () => new Dummy(),
+      (obj) => (obj.value = 0),
+    );
+    const a = pool.acquire();
+    a.value = 42;
+    pool.release(a);
+    const b = pool.acquire();
+    expect(b.value).toBe(0);
+    expect(a).toBe(b);
+    expect(pool.size()).toBe(0);
+  });
+});

--- a/src/core/pool.ts
+++ b/src/core/pool.ts
@@ -1,0 +1,26 @@
+// eslint-disable-next-line no-unused-vars
+type ResetFn<T> = (value: T) => void;
+
+export class ObjectPool<T> {
+  private pool: T[] = [];
+  private factory: () => T;
+  private reset: ResetFn<T>;
+
+  constructor(factory: () => T, reset: ResetFn<T>) {
+    this.factory = factory;
+    this.reset = reset;
+  }
+
+  acquire(): T {
+    return this.pool.pop() ?? this.factory();
+  }
+
+  release(obj: T): void {
+    this.reset(obj);
+    this.pool.push(obj);
+  }
+
+  size(): number {
+    return this.pool.length;
+  }
+}

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,0 +1,51 @@
+import Phaser from 'phaser';
+import { advanceOnPath, pathVector } from '../systems/path';
+
+export class Enemy {
+  private circle: Phaser.GameObjects.Arc;
+  private progress = 0;
+  private speed = 0;
+  private hp = 0;
+  private onDeath: (() => void) | null = null;
+  active = false;
+  path!: Phaser.Curves.Path;
+
+  constructor(private scene: Phaser.Scene) {
+    this.circle = scene.add.circle(0, 0, 10, 0xf87171);
+    this.circle.setActive(false).setVisible(false);
+    this.circle.setInteractive();
+    this.circle.on('pointerdown', () => {
+      this.hp = 0;
+    });
+  }
+
+  reset(path: Phaser.Curves.Path, speed: number, hp: number, onDeath: () => void) {
+    this.path = path;
+    this.speed = speed;
+    this.hp = hp;
+    this.onDeath = onDeath;
+    this.progress = 0;
+    this.active = true;
+    path.getPoint(0, pathVector);
+    this.circle.setPosition(pathVector.x, pathVector.y).setActive(true).setVisible(true);
+  }
+
+  update(delta: number): boolean {
+    if (!this.active) return false;
+    this.progress = advanceOnPath(this.path, this.progress, this.speed, delta, pathVector);
+    if (this.progress >= 1 || this.hp <= 0) {
+      this.deactivate();
+      if (this.onDeath) {
+        this.onDeath();
+      }
+      return true;
+    }
+    this.circle.setPosition(pathVector.x, pathVector.y);
+    return false;
+  }
+
+  deactivate() {
+    this.active = false;
+    this.circle.setActive(false).setVisible(false);
+  }
+}

--- a/src/entities/Projectile.ts
+++ b/src/entities/Projectile.ts
@@ -1,0 +1,41 @@
+import Phaser from 'phaser';
+
+export class Projectile {
+  private circle: Phaser.GameObjects.Arc;
+  private vx = 0;
+  private vy = 0;
+  active = false;
+
+  constructor(private scene: Phaser.Scene) {
+    this.circle = scene.add.circle(0, 0, 4, 0x22d3ee);
+    this.circle.setActive(false).setVisible(false);
+  }
+
+  fire(x: number, y: number, vx: number, vy: number) {
+    this.vx = vx;
+    this.vy = vy;
+    this.active = true;
+    this.circle.setPosition(x, y).setActive(true).setVisible(true);
+  }
+
+  update(delta: number): boolean {
+    if (!this.active) return false;
+    this.circle.x += this.vx * delta;
+    this.circle.y += this.vy * delta;
+    if (
+      this.circle.x < 0 ||
+      this.circle.x > this.scene.scale.width ||
+      this.circle.y < 0 ||
+      this.circle.y > this.scene.scale.height
+    ) {
+      this.deactivate();
+      return true;
+    }
+    return false;
+  }
+
+  deactivate() {
+    this.active = false;
+    this.circle.setActive(false).setVisible(false);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { BootScene } from './scenes/BootScene';
 import { GameScene } from './scenes/GameScene';
 import { HUDScene } from './scenes/HUDScene';
 
+export const PIXEL_RATIO = (window as Window & { PIXEL_RATIO?: number }).PIXEL_RATIO ?? 1;
+
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
   width: 960,
@@ -11,6 +13,9 @@ const config: Phaser.Types.Core.GameConfig = {
   pixelArt: true,
   backgroundColor: '#0f172a',
   scene: [BootScene, GameScene, HUDScene],
+  scale: {
+    zoom: PIXEL_RATIO,
+  },
 };
 
 export default new Phaser.Game(config);

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -9,45 +9,13 @@ import {
   STARTING_MONEY,
   WAVE_INTERVAL,
 } from '../core/balance';
+import { Enemy } from '../entities/Enemy';
+import { Projectile } from '../entities/Projectile';
+import { ObjectPool } from '../core/pool';
 
 const TILE_SIZE = 32;
 const GRID_WIDTH = 30;
 const GRID_HEIGHT = 17;
-
-class Enemy {
-  private circle: Phaser.GameObjects.Arc;
-  private progress = 0;
-  private dead = false;
-
-  constructor(
-    private scene: Phaser.Scene,
-    private path: Phaser.Curves.Path,
-    public speed: number,
-    public hp: number,
-    private onDeath: () => void,
-  ) {
-    this.circle = scene.add.circle(0, 0, 10, 0xf87171);
-    this.circle.setInteractive();
-    this.circle.on('pointerdown', () => {
-      this.dead = true;
-      this.circle.destroy();
-      this.onDeath();
-    });
-  }
-
-  update(delta: number) {
-    if (this.dead) return false;
-    this.progress += (this.speed * delta) / this.path.getLength();
-    if (this.progress >= 1) {
-      this.dead = true;
-      this.circle.destroy();
-      return true;
-    }
-    const pos = this.path.getPoint(this.progress);
-    this.circle.setPosition(pos.x, pos.y);
-    return false;
-  }
-}
 
 export class GameScene extends Phaser.Scene {
   private wave = 0;
@@ -55,6 +23,14 @@ export class GameScene extends Phaser.Scene {
   private money = STARTING_MONEY;
   private path!: Phaser.Curves.Path;
   private enemies: Enemy[] = [];
+  private projectiles: Projectile[] = [];
+  private enemyPool!: ObjectPool<Enemy>;
+  private projectilePool!: ObjectPool<Projectile>;
+  private profilerText!: Phaser.GameObjects.Text;
+  private profilerEnabled = false;
+  private updateTime = 0;
+  private updateSamples = 0;
+  private emitter!: Phaser.GameObjects.Particles.ParticleEmitter;
 
   constructor() {
     super('Game');
@@ -63,6 +39,14 @@ export class GameScene extends Phaser.Scene {
   create() {
     this.drawGrid();
     this.createPath();
+    this.enemyPool = new ObjectPool(
+      () => new Enemy(this),
+      (e) => e.deactivate(),
+    );
+    this.projectilePool = new ObjectPool(
+      () => new Projectile(this),
+      (p) => p.deactivate(),
+    );
     this.time.addEvent({
       delay: WAVE_INTERVAL,
       loop: true,
@@ -70,17 +54,63 @@ export class GameScene extends Phaser.Scene {
       callbackScope: this,
     });
     this.spawnWave();
+    this.profilerText = this.add
+      .text(4, 4, '', { fontSize: '12px', color: '#fff' })
+      .setDepth(100)
+      .setVisible(false);
+    this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.F3).on('down', () => {
+      this.profilerEnabled = !this.profilerEnabled;
+      this.profilerText.setVisible(this.profilerEnabled);
+    });
+    const particles = this.add.particles(0xffffff);
+    this.emitter = (particles as any).createEmitter({
+      speed: 20,
+      lifespan: 500,
+      quantity: 1,
+    });
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      const proj = this.projectilePool.acquire();
+      const dx = pointer.x;
+      const dy = pointer.y;
+      const len = Math.hypot(dx, dy) || 1;
+      const speed = 0.4;
+      proj.fire(0, 0, (dx / len) * speed, (dy / len) * speed);
+      this.projectiles.push(proj);
+    });
     events.emit('stats', { wave: this.wave, lives: this.lives, money: this.money });
   }
 
   update(_time: number, delta: number) {
+    const start = performance.now();
     for (let i = this.enemies.length - 1; i >= 0; i--) {
       const enemy = this.enemies[i];
       if (enemy.update(delta)) {
         this.enemies.splice(i, 1);
+        this.enemyPool.release(enemy);
         this.lives -= 1;
         events.emit('stats', { wave: this.wave, lives: this.lives, money: this.money });
       }
+    }
+    for (let i = this.projectiles.length - 1; i >= 0; i--) {
+      const proj = this.projectiles[i];
+      if (proj.update(delta)) {
+        this.projectiles.splice(i, 1);
+        this.projectilePool.release(proj);
+      }
+    }
+    const duration = performance.now() - start;
+    this.updateTime += duration;
+    this.updateSamples += 1;
+    if (this.profilerEnabled) {
+      const avg = this.updateTime / this.updateSamples;
+      this.profilerText.setText(
+        `E:${this.enemies.length} P:${this.projectiles.length}\nupd:${avg.toFixed(2)}ms`,
+      );
+    }
+    if (this.game.loop.actualFps < 50) {
+      this.emitter.setQuantity(0);
+    } else {
+      this.emitter.setQuantity(1);
     }
   }
 
@@ -113,10 +143,15 @@ export class GameScene extends Phaser.Scene {
   private spawnWave() {
     this.wave += 1;
     for (let i = 0; i < ENEMIES_PER_WAVE; i++) {
-      const enemy = new Enemy(this, this.path, ENEMY_SPEED, ENEMY_HP, () => {
+      const enemy = this.enemyPool.acquire();
+      enemy.reset(this.path, ENEMY_SPEED, ENEMY_HP, () => {
         this.money += ENEMY_REWARD;
         events.emit('stats', { wave: this.wave, lives: this.lives, money: this.money });
-        this.enemies = this.enemies.filter((e) => e !== enemy);
+        const idx = this.enemies.indexOf(enemy);
+        if (idx !== -1) {
+          this.enemies.splice(idx, 1);
+        }
+        this.enemyPool.release(enemy);
       });
       this.enemies.push(enemy);
     }

--- a/src/systems/path.ts
+++ b/src/systems/path.ts
@@ -1,0 +1,17 @@
+import Phaser from 'phaser';
+
+const tmp = new Phaser.Math.Vector2();
+
+export function advanceOnPath(
+  path: Phaser.Curves.Path,
+  progress: number,
+  speed: number,
+  delta: number,
+  out: Phaser.Math.Vector2 = tmp,
+): number {
+  progress += (speed * delta) / path.getLength();
+  path.getPoint(progress, out);
+  return progress;
+}
+
+export { tmp as pathVector };


### PR DESCRIPTION
## Summary
- pool enemies and projectiles to reuse objects instead of allocating every frame
- batch updates and move path progression into a dedicated system
- add toggleable in-game profiler and pixel ratio switch

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689679c881008322850b25134442ab12