### PR TITLE
perf: pooling + update batching

### DIFF
--- a/src/core/pool.test.ts
+++ b/src/core/pool.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectPool } from './pool';
+
+describe('ObjectPool', () => {
+  it('reuses released objects', () => {
+    let counter = 0;
+    const pool = new ObjectPool(
+      () => ({ id: counter++ }),
+      () => {},
+    );
+    const a = pool.acquire();
+    pool.acquire();
+    pool.release(a);
+    const c = pool.acquire();
+    expect(c).toBe(a);
+    expect(pool.size()).toBe(0);
+    expect(counter).toBe(2);
+  });
+});

--- a/src/core/pool.ts
+++ b/src/core/pool.ts
@@ -1,0 +1,27 @@
+export type Factory<T> = () => T;
+export type Resetter<T> = (item: T) => void;
+
+export class ObjectPool<T> {
+  private pool: T[] = [];
+  constructor(
+    private factory: Factory<T>,
+    private reset: Resetter<T>,
+  ) {}
+
+  acquire(): T {
+    return this.pool.pop() ?? this.factory();
+  }
+
+  release(item: T) {
+    this.reset(item);
+    this.pool.push(item);
+  }
+
+  clear() {
+    this.pool.length = 0;
+  }
+
+  size() {
+    return this.pool.length;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,19 @@ import { BootScene } from './scenes/BootScene';
 import { GameScene } from './scenes/GameScene';
 import { HUDScene } from './scenes/HUDScene';
 
-const config: Phaser.Types.Core.GameConfig = {
+interface RatioWindow {
+  PIXEL_RATIO?: number;
+}
+const ratioWindow = window as unknown as RatioWindow;
+export const PIXEL_RATIO = ratioWindow.PIXEL_RATIO ?? 1;
+
+const config: Phaser.Types.Core.GameConfig & { resolution: number } = {
   type: Phaser.AUTO,
   width: 960,
   height: 540,
   parent: 'app',
   pixelArt: true,
+  resolution: PIXEL_RATIO,
   backgroundColor: '#0f172a',
   scene: [BootScene, GameScene, HUDScene],
 };

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -16,40 +16,46 @@ import {
 } from '../core/balance';
 import { worldToGrid } from '../core/grid';
 import { selectTarget, Targetable } from '../core/targeting';
+import { ObjectPool } from '../core/pool';
+import { updatePath } from '../systems/path';
 
 const TILE_SIZE = 32;
 const GRID_WIDTH = 30;
 const GRID_HEIGHT = 17;
 
-class Enemy implements Targetable {
-  private circle: Phaser.GameObjects.Arc;
-  private progressValue = 0;
-  private dead = false;
-  private scene: Phaser.Scene;
-  private path: Phaser.Curves.Path;
-  public speed: number;
-  public hp: number;
-  private onDeath: () => void;
+export class Enemy implements Targetable {
+  circle: Phaser.GameObjects.Arc;
+  progress = 0;
+  dead = false;
+  path!: Phaser.Curves.Path;
+  speed = ENEMY_SPEED;
+  hp = ENEMY_HP;
+  onDeath!: () => void;
 
-  constructor(
-    scene: Phaser.Scene,
-    path: Phaser.Curves.Path,
-    speed: number,
-    hp: number,
-    onDeath: () => void,
-  ) {
-    this.scene = scene;
+  constructor(private scene: Phaser.Scene) {
+    this.circle = scene.add.circle(0, 0, 10, 0xf87171).setActive(false).setVisible(false);
+    this.circle.setInteractive();
+    this.circle.on('pointerdown', () => {
+      this.dead = true;
+      this.circle.setActive(false).setVisible(false);
+      this.onDeath?.();
+    });
+  }
+
+  spawn(path: Phaser.Curves.Path, speed: number, hp: number, onDeath: () => void) {
     this.path = path;
     this.speed = speed;
     this.hp = hp;
     this.onDeath = onDeath;
-    this.circle = scene.add.circle(0, 0, 10, 0xf87171);
-    this.circle.setInteractive();
-    this.circle.on('pointerdown', () => {
-      this.dead = true;
-      this.circle.destroy();
-      this.onDeath();
-    });
+    this.progress = 0;
+    this.dead = false;
+    this.circle.setActive(true).setVisible(true);
+  }
+
+  reset() {
+    this.circle.setActive(false).setVisible(false);
+    this.dead = false;
+    this.progress = 0;
   }
 
   get x() {
@@ -60,64 +66,42 @@ class Enemy implements Targetable {
     return this.circle.y;
   }
 
-  get progress() {
-    return this.progressValue;
-  }
-
-  isDead() {
-    return this.dead;
-  }
-
   takeDamage(amount: number) {
     if (this.dead) return;
     this.hp -= amount;
     if (this.hp <= 0) {
       this.dead = true;
-      this.circle.destroy();
+      this.circle.setActive(false).setVisible(false);
       this.onDeath();
     }
   }
-
-  update(delta: number) {
-    if (this.dead) return false;
-    this.progressValue += (this.speed * delta) / this.path.getLength();
-    if (this.progressValue >= 1) {
-      this.dead = true;
-      this.circle.destroy();
-      return true;
-    }
-    const pos = this.path.getPoint(this.progressValue);
-    this.circle.setPosition(pos.x, pos.y);
-    return false;
-  }
 }
 
-class Projectile {
-  private circle: Phaser.GameObjects.Arc;
-  private dead = false;
-  private scene: Phaser.Scene;
-  private target: Enemy;
-  public speed: number;
-  public damage: number;
+export class Projectile {
+  circle: Phaser.GameObjects.Arc;
+  dead = false;
+  target!: Enemy;
+  speed = PROJECTILE_SPEED;
+  damage = PROJECTILE_DAMAGE;
 
-  constructor(
-    scene: Phaser.Scene,
-    target: Enemy,
-    speed: number,
-    damage: number,
-    x: number,
-    y: number,
-  ) {
-    this.scene = scene;
+  constructor(private scene: Phaser.Scene) {
+    this.circle = scene.add.circle(0, 0, 3, 0xfacc15).setActive(false).setVisible(false);
+  }
+
+  fire(target: Enemy, x: number, y: number) {
     this.target = target;
-    this.speed = speed;
-    this.damage = damage;
-    this.circle = scene.add.circle(x, y, 3, 0xfacc15);
+    this.dead = false;
+    this.circle.setPosition(x, y).setActive(true).setVisible(true);
+  }
+
+  reset() {
+    this.circle.setActive(false).setVisible(false);
+    this.dead = false;
   }
 
   update(delta: number) {
-    if (this.dead || this.target.isDead()) {
-      this.circle.destroy();
+    if (this.dead || this.target.dead) {
+      this.circle.setActive(false).setVisible(false);
       return true;
     }
     const dx = this.target.x - this.circle.x;
@@ -126,8 +110,8 @@ class Projectile {
     const move = (this.speed * delta) / 1000;
     if (dist <= move) {
       this.target.takeDamage(this.damage);
-      this.circle.destroy();
       this.dead = true;
+      this.circle.setActive(false).setVisible(false);
       return true;
     }
     this.circle.x += (dx / dist) * move;
@@ -139,29 +123,26 @@ class Projectile {
 class Tower {
   private rect: Phaser.GameObjects.Rectangle;
   private lastShot = 0;
-  private scene: Phaser.Scene;
-  public x: number;
-  public y: number;
-  public range: number;
-  public fireRate: number;
-
-  constructor(scene: Phaser.Scene, x: number, y: number, range: number, fireRate: number) {
-    this.scene = scene;
-    this.x = x;
-    this.y = y;
-    this.range = range;
-    this.fireRate = fireRate;
+  constructor(
+    private scene: GameScene,
+    public x: number,
+    public y: number,
+    public range: number,
+    public fireRate: number,
+  ) {
     this.rect = scene.add.rectangle(x, y, TILE_SIZE, TILE_SIZE, 0x60a5fa);
   }
 
-  update(delta: number, enemies: Enemy[], projectiles: Projectile[]) {
+  update(delta: number, enemies: Enemy[]) {
     this.lastShot += delta;
     if (this.lastShot < 1000 / this.fireRate) return;
     const target = selectTarget(enemies, this.x, this.y, this.range) as Enemy | undefined;
     if (target) {
-      projectiles.push(
-        new Projectile(this.scene, target, PROJECTILE_SPEED, PROJECTILE_DAMAGE, this.x, this.y),
-      );
+      if (this.scene.game.loop.actualFps >= 50 || this.scene.projectiles.length < 100) {
+        const p = this.scene.projectilePool.acquire();
+        p.fire(target, this.x, this.y);
+        this.scene.projectiles.push(p);
+      }
       this.lastShot = 0;
     }
   }
@@ -174,11 +155,17 @@ export class GameScene extends Phaser.Scene {
   private path!: Phaser.Curves.Path;
   private enemies: Enemy[] = [];
   private towers: Tower[] = [];
-  private projectiles: Projectile[] = [];
+  public projectiles: Projectile[] = [];
   private occupied = new Set<string>();
   private previewTower!: Phaser.GameObjects.Rectangle;
   private previewRange!: Phaser.GameObjects.Arc;
   private paused = false;
+  private enemyPool!: ObjectPool<Enemy>;
+  public projectilePool!: ObjectPool<Projectile>;
+  private profilerText!: Phaser.GameObjects.Text;
+  private profiler = false;
+  private updateTotal = 0;
+  private updateSamples = 0;
 
   constructor() {
     super('Game');
@@ -187,6 +174,23 @@ export class GameScene extends Phaser.Scene {
   create() {
     this.drawGrid();
     this.createPath();
+    this.enemyPool = new ObjectPool(
+      () => new Enemy(this),
+      (e) => e.reset(),
+    );
+    this.projectilePool = new ObjectPool(
+      () => new Projectile(this),
+      (p) => p.reset(),
+    );
+    this.profilerText = this.add
+      .text(10, 10, '', { color: '#fff' })
+      .setDepth(1000)
+      .setVisible(false);
+    this.input.keyboard?.on('keydown-F3', () => {
+      this.profiler = !this.profiler;
+      this.profilerText.setVisible(this.profiler);
+    });
+
     this.time.addEvent({
       delay: WAVE_INTERVAL,
       loop: true,
@@ -239,23 +243,45 @@ export class GameScene extends Phaser.Scene {
 
   update(_time: number, delta: number) {
     if (this.paused) return;
+    const start = performance.now();
+
     for (let i = this.enemies.length - 1; i >= 0; i--) {
       const enemy = this.enemies[i];
-      if (enemy.update(delta)) {
+      if (updatePath(enemy, delta)) {
         this.enemies.splice(i, 1);
         this.lives -= 1;
         events.emit('stats', { wave: this.wave, lives: this.lives, money: this.money });
+        this.enemyPool.release(enemy);
+        continue;
+      }
+      if (enemy.dead) {
+        this.enemies.splice(i, 1);
+        this.enemyPool.release(enemy);
       }
     }
 
     for (const tower of this.towers) {
-      tower.update(delta, this.enemies, this.projectiles);
+      tower.update(delta, this.enemies);
     }
 
     for (let i = this.projectiles.length - 1; i >= 0; i--) {
-      if (this.projectiles[i].update(delta)) {
+      const p = this.projectiles[i];
+      if (p.update(delta)) {
         this.projectiles.splice(i, 1);
+        this.projectilePool.release(p);
       }
+    }
+
+    const duration = performance.now() - start;
+    this.updateTotal += duration;
+    this.updateSamples += 1;
+    if (this.profiler && this.updateSamples >= 20) {
+      const avg = this.updateTotal / this.updateSamples;
+      this.profilerText.setText(
+        `E:${this.enemies.length} P:${this.projectiles.length} U:${avg.toFixed(2)}ms`,
+      );
+      this.updateTotal = 0;
+      this.updateSamples = 0;
     }
   }
 
@@ -288,10 +314,10 @@ export class GameScene extends Phaser.Scene {
   private spawnWave() {
     this.wave += 1;
     for (let i = 0; i < ENEMIES_PER_WAVE; i++) {
-      const enemy = new Enemy(this, this.path, ENEMY_SPEED, ENEMY_HP, () => {
+      const enemy = this.enemyPool.acquire();
+      enemy.spawn(this.path, ENEMY_SPEED, ENEMY_HP, () => {
         this.money += ENEMY_REWARD;
         events.emit('stats', { wave: this.wave, lives: this.lives, money: this.money });
-        this.enemies = this.enemies.filter((e) => e !== enemy);
       });
       this.enemies.push(enemy);
     }

--- a/src/systems/path.ts
+++ b/src/systems/path.ts
@@ -1,0 +1,17 @@
+import Phaser from 'phaser';
+import type { Enemy } from '../scenes/GameScene';
+
+const tmp = new Phaser.Math.Vector2();
+
+export function updatePath(enemy: Enemy, delta: number) {
+  if (enemy.dead) return true;
+  enemy.progress += (enemy.speed * delta) / enemy.path.getLength();
+  if (enemy.progress >= 1) {
+    enemy.dead = true;
+    enemy.circle.setActive(false).setVisible(false);
+    return true;
+  }
+  enemy.path.getPoint(enemy.progress, tmp);
+  enemy.circle.setPosition(tmp.x, tmp.y);
+  return false;
+}


### PR DESCRIPTION
## Summary
- introduce reusable pools for enemies and projectiles
- batch path updates and add F3 profiler overlay
- expose PIXEL_RATIO switch and throttle projectiles when FPS is low

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689687fd013c8322b395a26be3e654da