### PR TITLE
feat: Arrow/Cannon/Frost + status system

### DIFF
--- a/src/core/balance.ts
+++ b/src/core/balance.ts
@@ -6,9 +6,29 @@ export const ENEMY_SPEED = 60; // pixels per second
 export const ENEMY_HP = 1;
 export const ENEMY_REWARD = 5;
 
-export const TOWER_COST = 20;
-export const TOWER_RANGE = 100;
-export const TOWER_FIRE_RATE = 1; // shots per second
+export interface TowerStats {
+  cost: number;
+  range: number;
+  fireRate: number; // shots per second
+  damage: number;
+  aoeRadius?: number;
+  slowPct?: number; // 0-1
+  slowDur?: number; // ms
+  dotDamage?: number; // damage per second
+  dotDur?: number; // ms
+}
+
+export const TOWERS: Record<string, TowerStats> = {
+  arrow: { cost: 20, range: 100, fireRate: 1.5, damage: 1 },
+  cannon: { cost: 40, range: 90, fireRate: 0.5, damage: 2, aoeRadius: 40 },
+  frost: {
+    cost: 30,
+    range: 90,
+    fireRate: 1,
+    damage: 0,
+    slowPct: 0.3,
+    slowDur: 2000,
+  },
+};
 
 export const PROJECTILE_SPEED = 300; // pixels per second
-export const PROJECTILE_DAMAGE = 1;

--- a/src/core/status.test.ts
+++ b/src/core/status.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { addStatus, updateStatuses, Status } from './status';
+
+describe('status system', () => {
+  it('applies slow and dot correctly with timers', () => {
+    const statuses: Status[] = [];
+    addStatus(statuses, { type: 'slow', value: 0.3, remaining: 2000 }, 1);
+    addStatus(statuses, { type: 'dot', value: 2, remaining: 1000 }, 3);
+    let result = updateStatuses(statuses, 1000);
+    expect(result.slow).toBeCloseTo(0.3);
+    expect(result.damage).toBeCloseTo(2);
+    result = updateStatuses(statuses, 1000);
+    expect(result.slow).toBeCloseTo(0.3);
+    expect(result.damage).toBeCloseTo(0);
+    result = updateStatuses(statuses, 1000);
+    expect(result.slow).toBeCloseTo(0);
+  });
+});

--- a/src/core/status.ts
+++ b/src/core/status.ts
@@ -1,0 +1,32 @@
+export type StatusType = 'slow' | 'dot';
+
+export interface Status {
+  type: StatusType;
+  value: number;
+  remaining: number; // ms
+}
+
+export function addStatus(statuses: Status[], status: Status, maxStacks: number) {
+  const same = statuses.filter((s) => s.type === status.type);
+  if (same.length >= maxStacks) {
+    const index = statuses.indexOf(same[0]);
+    statuses.splice(index, 1);
+  }
+  statuses.push({ ...status });
+}
+
+export function updateStatuses(statuses: Status[], delta: number) {
+  let slow = 0;
+  let damage = 0;
+  for (let i = statuses.length - 1; i >= 0; i--) {
+    const s = statuses[i];
+    s.remaining -= delta;
+    if (s.type === 'slow') {
+      slow += s.value;
+    } else if (s.type === 'dot') {
+      damage += (s.value * delta) / 1000;
+    }
+    if (s.remaining <= 0) statuses.splice(i, 1);
+  }
+  return { slow, damage };
+}

--- a/src/scenes/HUDScene.ts
+++ b/src/scenes/HUDScene.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { events } from '../core/events';
+import { TOWERS } from '../core/balance';
 
 export class HUDScene extends Phaser.Scene {
   private statsText!: Phaser.GameObjects.Text;
@@ -20,5 +21,18 @@ export class HUDScene extends Phaser.Scene {
       },
       this,
     );
+
+    const types = Object.keys(TOWERS);
+    types.forEach((type, idx) => {
+      const stats = TOWERS[type];
+      this.add
+        .text(10 + idx * 100, 40, `${type} ($${stats.cost})`, {
+          color: '#ffffff',
+          backgroundColor: '#334155',
+        })
+        .setPadding(4)
+        .setInteractive({ useHandCursor: true })
+        .on('pointerdown', () => events.emit('tower-select', type));
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add centralized tower stats and Arrow/Cannon/Frost definitions
- implement enemy status system with slow/DoT, AoE cannon projectiles, and tower selection UI
- add unit test for status timers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968bb86c4483229f9c61a3fffa000e