### PR TITLE
feat: economy + tower upgrades + sell

### DIFF
--- a/src/core/balance.ts
+++ b/src/core/balance.ts
@@ -7,7 +7,6 @@ export const ENEMY_HP = 1;
 export const ENEMY_REWARD = 5;
 
 export interface TowerStats {
-  cost: number;
   range: number;
   fireRate: number; // shots per second
   damage: number;
@@ -18,16 +17,35 @@ export interface TowerStats {
   dotDur?: number; // ms
 }
 
-export const TOWERS: Record<string, TowerStats> = {
-  arrow: { cost: 20, range: 100, fireRate: 1.5, damage: 1 },
-  cannon: { cost: 40, range: 90, fireRate: 0.5, damage: 2, aoeRadius: 40 },
+export interface TowerConfig {
+  cost: number;
+  levels: TowerStats[];
+}
+
+export const TOWERS: Record<string, TowerConfig> = {
+  arrow: {
+    cost: 20,
+    levels: [
+      { range: 100, fireRate: 1.5, damage: 1 },
+      { range: 120, fireRate: 1.8, damage: 2 },
+      { range: 140, fireRate: 2.1, damage: 3 },
+    ],
+  },
+  cannon: {
+    cost: 40,
+    levels: [
+      { range: 90, fireRate: 0.5, damage: 2, aoeRadius: 40 },
+      { range: 100, fireRate: 0.6, damage: 3, aoeRadius: 40 },
+      { range: 110, fireRate: 0.7, damage: 4, aoeRadius: 40 },
+    ],
+  },
   frost: {
     cost: 30,
-    range: 90,
-    fireRate: 1,
-    damage: 0,
-    slowPct: 0.3,
-    slowDur: 2000,
+    levels: [
+      { range: 90, fireRate: 1, damage: 0, slowPct: 0.3, slowDur: 2000 },
+      { range: 100, fireRate: 1.2, damage: 0, slowPct: 0.4, slowDur: 2000 },
+      { range: 110, fireRate: 1.5, damage: 0, slowPct: 0.5, slowDur: 2000 },
+    ],
   },
 };
 

--- a/src/core/economy.test.ts
+++ b/src/core/economy.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { upgradeCost, totalCost, sellRefund, canAfford } from './economy';
+
+describe('economy', () => {
+  it('calculates upgrade and total cost', () => {
+    expect(upgradeCost(100, 1)).toBe(160);
+    expect(upgradeCost(100, 2)).toBe(256);
+    expect(totalCost(100, 3)).toBe(516);
+  });
+
+  it('computes sell refund', () => {
+    expect(sellRefund(100, 3)).toBe(Math.round(516 * 0.7));
+  });
+
+  it('prevents purchase when funds insufficient', () => {
+    expect(canAfford(50, 60)).toBe(false);
+    expect(canAfford(60, 60)).toBe(true);
+  });
+});

--- a/src/core/economy.ts
+++ b/src/core/economy.ts
@@ -1,0 +1,21 @@
+export const UPGRADE_FACTOR = 1.6;
+
+export function upgradeCost(base: number, level: number) {
+  return Math.round(base * Math.pow(UPGRADE_FACTOR, level));
+}
+
+export function totalCost(base: number, level: number) {
+  let total = base;
+  for (let i = 1; i < level; i++) {
+    total += upgradeCost(base, i);
+  }
+  return total;
+}
+
+export function sellRefund(base: number, level: number) {
+  return Math.round(totalCost(base, level) * 0.7);
+}
+
+export function canAfford(money: number, cost: number) {
+  return money >= cost;
+}

--- a/src/scenes/HUDScene.ts
+++ b/src/scenes/HUDScene.ts
@@ -24,9 +24,9 @@ export class HUDScene extends Phaser.Scene {
 
     const types = Object.keys(TOWERS);
     types.forEach((type, idx) => {
-      const stats = TOWERS[type];
+      const cfg = TOWERS[type];
       this.add
-        .text(10 + idx * 100, 40, `${type} ($${stats.cost})`, {
+        .text(10 + idx * 100, 40, `${type} ($${cfg.cost})`, {
           color: '#ffffff',
           backgroundColor: '#334155',
         })


### PR DESCRIPTION
## Summary
- add per-tower upgrade stats and costs
- enable tower upgrades and selling with refund
- test economy calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68970966f6948322b127f0744526ee08