### PR TITLE
feat: add right drawer sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <body>
     <div id="app"></div>
     <div id="hud-root"></div>
-    <div id="tool-sidebar"></div>
+    <aside id="tool-sidebar" aria-label="Build & Actions"></aside>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/ui/SidebarController.ts
+++ b/src/ui/SidebarController.ts
@@ -1,5 +1,5 @@
 import { setMode, cancelMode, InputMode } from '../core/inputMode';
-import { TOWERS } from '../core/balance';
+import { TOWERS, TowerConfig } from '../core/balance';
 import { sound } from '../audio/SoundManager';
 import { events } from '../core/events';
 import { ArrowIcon, CannonIcon, FrostIcon } from './icons';
@@ -10,21 +10,22 @@ export class SidebarController {
     if (!root) return;
     root.innerHTML = `
       <div class="section build">
-        <button data-mode="build:arrow">${ArrowIcon}<span>Arrow $${TOWERS.arrow.cost}</span></button>
-        <button data-mode="build:cannon">${CannonIcon}<span>Cannon $${TOWERS.cannon.cost}</span></button>
-        <button data-mode="build:frost">${FrostIcon}<span>Frost $${TOWERS.frost.cost}</span></button>
+        ${this.card('arrow', 'Arrow', ArrowIcon)}
+        ${this.card('cannon', 'Cannon', CannonIcon)}
+        ${this.card('frost', 'Frost', FrostIcon)}
       </div>
       <div class="section modes">
         <button data-mode="upgrade">Upgrade</button>
         <button data-mode="sell">Sell</button>
       </div>
     `;
-    const buttons = Array.from(root.querySelectorAll('button')) as HTMLButtonElement[];
+    const buttons = Array.from(root.querySelectorAll('button[data-mode]')) as HTMLButtonElement[];
     buttons.forEach((btn) =>
       btn.addEventListener('click', () => {
         sound.playUIClick();
         const mode = btn.getAttribute('data-mode') as InputMode;
         setMode(mode);
+        if (window.innerWidth <= 700) root.classList.remove('open');
       }),
     );
     events.on('modeChanged', (m: string) => {
@@ -38,5 +39,38 @@ export class SidebarController {
       else if (e.key.toLowerCase() === 'v') setMode('sell');
       else if (e.key === 'Escape') cancelMode();
     });
+
+    const toggle = document.createElement('button');
+    toggle.id = 'sidebar-toggle';
+    toggle.setAttribute('aria-label', 'Toggle build menu');
+    toggle.textContent = '🛠';
+    toggle.addEventListener('click', () => {
+      root.classList.toggle('open');
+    });
+    document.body.appendChild(toggle);
+  }
+
+  private card(type: keyof typeof TOWERS, name: string, icon: string) {
+    const cfg: TowerConfig = TOWERS[type];
+    const stats = cfg.levels[0];
+    const dps = (stats.damage * stats.fireRate).toFixed(1);
+    const effect = stats.aoeRadius
+      ? 'AoE'
+      : stats.slowPct
+        ? `Slow ${Math.round(stats.slowPct * 100)}%`
+        : 'Single';
+    return `
+      <button class="tower-card" data-mode="build:${type}">
+        ${icon}
+        <div class="info">
+          <div class="title"><span>${name}</span><span>$${cfg.cost}</span></div>
+          <ul class="stats">
+            <li>DPS ${dps}</li>
+            <li>Range ${stats.range}</li>
+            <li>${effect}</li>
+          </ul>
+        </div>
+      </button>
+    `;
   }
 }

--- a/src/ui/hud.css
+++ b/src/ui/hud.css
@@ -18,7 +18,14 @@
   position: fixed;
   inset: 0;
   pointer-events: none;
-  font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    Arial,
+    sans-serif;
   color: var(--text);
   font-size: clamp(12px, 2vw, 16px);
 }
@@ -66,13 +73,14 @@ button:focus-visible {
 .settings {
   position: fixed;
   top: 60px;
-  right: 12px;
+  right: calc(var(--sidebar-width) + 32px);
   background: var(--panel);
   backdrop-filter: blur(6px);
   border: 1px solid var(--panel-border);
   border-radius: 12px;
   padding: 12px;
   pointer-events: auto;
+  z-index: 6;
 }
 .settings.hidden {
   display: none;
@@ -148,5 +156,11 @@ button:focus-visible {
 @media (max-width: 480px) {
   .hud-top .label {
     display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .settings {
+    right: 12px;
   }
 }

--- a/src/ui/sidebar.css
+++ b/src/ui/sidebar.css
@@ -1,17 +1,22 @@
+:root {
+  --sidebar-width: 300px;
+}
+
 #tool-sidebar {
   position: fixed;
-  top: 90px;
+  top: 96px;
   right: 16px;
-  width: 280px;
+  width: var(--sidebar-width);
   backdrop-filter: blur(8px);
   border-radius: 14px;
-  box-shadow: 0 4px 12px #0006;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   padding: 12px;
   background: rgba(0, 0, 0, 0.4);
   color: #fff;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  z-index: 5;
 }
 
 #tool-sidebar .section {
@@ -20,10 +25,48 @@
   gap: 8px;
 }
 
-#tool-sidebar button {
+#tool-sidebar .tower-card {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
+  padding: 8px;
+  border: 1px solid #ffffff20;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+#tool-sidebar .tower-card[aria-pressed='true'] {
+  background: #ffffff20;
+}
+
+#tool-sidebar .tower-card svg {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+#tool-sidebar .info {
+  flex: 1;
+}
+
+#tool-sidebar .title {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+#tool-sidebar .stats {
+  list-style: disc;
+  margin: 0;
+  padding-left: 16px;
+  font-size: 12px;
+}
+
+#tool-sidebar .modes button {
   padding: 8px;
   border: 1px solid #ffffff20;
   border-radius: 8px;
@@ -32,11 +75,40 @@
   cursor: pointer;
 }
 
-#tool-sidebar button[aria-pressed="true"] {
+#tool-sidebar .modes button[aria-pressed='true'] {
   background: #ffffff20;
 }
 
-#tool-sidebar svg {
-  width: 24px;
-  height: 24px;
+#sidebar-toggle {
+  display: none;
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #ffffff20;
+  backdrop-filter: blur(8px);
+  color: #fff;
+  cursor: pointer;
+  z-index: 6;
+}
+
+@media (max-width: 900px) {
+  :root {
+    --sidebar-width: 260px;
+  }
+}
+
+@media (max-width: 700px) {
+  #tool-sidebar {
+    display: none;
+  }
+  #tool-sidebar.open {
+    display: flex;
+  }
+  #sidebar-toggle {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Summary
- add right-hand drawer for tower building and actions
- show tower cards with cost, DPS, range and effect
- support hotkeys, mobile toggle and spacing around settings

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68976329c1688322b72ecdeaefe2a500