### PR TITLE
Add anchored tower panel with upgrade & sell actions

### DIFF
--- a/src/ui/TowerPanel.test.ts
+++ b/src/ui/TowerPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calcPreview, TowerLike } from './TowerPanel';
+import { calcPreview, type TowerLike } from './towerPanelPreview';
 import { TOWERS } from '../core/balance';
 import { upgradeCost, sellRefund } from '../core/economy';
 

--- a/src/ui/hud.css
+++ b/src/ui/hud.css
@@ -125,12 +125,28 @@ button:focus-visible {
   width: 140px;
   font-size: 12px;
 }
+.tower-panel::after {
+  content: '';
+  position: absolute;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid var(--panel);
+  top: 100%;
+  left: calc(var(--arrow-x, 0px) - 8px);
+}
 .tower-panel.hidden {
   display: none;
 }
 .tower-panel button {
   width: 100%;
   margin-top: 4px;
+}
+.tower-panel .inc {
+  color: var(--success);
+  margin-left: 2px;
+}
+.tower-panel button.danger {
+  background: var(--danger);
 }
 
 .speed-group {

--- a/src/ui/towerPanelPreview.ts
+++ b/src/ui/towerPanelPreview.ts
@@ -1,0 +1,19 @@
+import { TOWERS, type TowerStats } from '../core/balance';
+import { upgradeCost, sellRefund } from '../core/economy';
+
+export interface TowerLike {
+  x: number;
+  y: number;
+  type: string;
+  level: number;
+  stats: TowerStats;
+}
+
+export function calcPreview(tower: TowerLike) {
+  const cfg = TOWERS[tower.type];
+  const before = cfg.levels[tower.level - 1];
+  const after = cfg.levels[tower.level] ?? null;
+  const upgrade = tower.level < cfg.levels.length ? upgradeCost(cfg.cost, tower.level) : 0;
+  const refund = sellRefund(cfg.cost, tower.level);
+  return { before, after, upgrade, refund };
+}


### PR DESCRIPTION
## Summary
- Show contextual tower panel with stat preview, upgrade cost, and sell button
- Handle tower clicks via group hit-test and keep focus trapped in panel
- Style tower panel with arrow indicator and feedback classes

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689766b8aef08322b19619a67574216c