### PR TITLE
fix: improve tower targeting and projectile effects

### DIFF
--- a/src/entities/EnemyManager.ts
+++ b/src/entities/EnemyManager.ts
@@ -1,0 +1,39 @@
+export interface Enemy {
+  x: number;
+  y: number;
+  progress: number;
+  dead: boolean;
+  takeDamage(amount: number): void;
+  addSlow?(pct: number, dur: number): void;
+}
+
+export class EnemyManager {
+  private enemies: Enemy[] = [];
+
+  add(enemy: Enemy) {
+    this.enemies.push(enemy);
+  }
+
+  getEnemiesInRange(x: number, y: number, range: number): Enemy[] {
+    const r2 = range * range;
+    return this.enemies.filter((e) => {
+      if (e.dead) return false;
+      const dx = e.x - x;
+      const dy = e.y - y;
+      return dx * dx + dy * dy <= r2;
+    });
+  }
+
+  getMostAdvancedInRange(x: number, y: number, range: number): Enemy | undefined {
+    let best: Enemy | undefined;
+    let bestProgress = -Infinity;
+    const inRange = this.getEnemiesInRange(x, y, range);
+    for (const enemy of inRange) {
+      if (enemy.progress > bestProgress) {
+        best = enemy;
+        bestProgress = enemy.progress;
+      }
+    }
+    return best;
+  }
+}

--- a/src/entities/Projectile.ts
+++ b/src/entities/Projectile.ts
@@ -1,0 +1,99 @@
+import { Enemy, EnemyManager } from './EnemyManager';
+import { ObjectPool } from '../core/pool';
+
+export type ProjectileType = 'arrow' | 'cannon' | 'frost';
+
+interface ProjectileConfig {
+  speed: number; // pixels per second
+  damage: number;
+  explosionRadius?: number;
+  slowPct?: number;
+  slowDur?: number;
+}
+
+const CONFIG: Record<ProjectileType, ProjectileConfig> = {
+  arrow: { speed: 400, damage: 1 },
+  cannon: { speed: 200, damage: 2, explosionRadius: 30 },
+  frost: { speed: 300, damage: 0, slowPct: 0.3, slowDur: 2 },
+};
+
+export class Projectile {
+  x = 0;
+  y = 0;
+  target!: Enemy;
+  active = false;
+  private cfg!: ProjectileConfig;
+  private enemies: EnemyManager;
+  constructor(manager: EnemyManager) {
+    this.enemies = manager;
+  }
+
+  fire(type: ProjectileType, x: number, y: number, target: Enemy) {
+    this.cfg = CONFIG[type];
+    this.x = x;
+    this.y = y;
+    this.target = target;
+    this.active = true;
+  }
+
+  reset() {
+    this.active = false;
+  }
+
+  update(dt: number): boolean {
+    if (!this.active) return true;
+    if (this.target.dead) {
+      this.active = false;
+      return true;
+    }
+    const dx = this.target.x - this.x;
+    const dy = this.target.y - this.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const move = this.cfg.speed * dt;
+    if (dist <= move) {
+      this.hit();
+      return true;
+    }
+    this.x += (dx / dist) * move;
+    this.y += (dy / dist) * move;
+    return false;
+  }
+
+  private hit() {
+    if (this.cfg.explosionRadius) {
+      const victims = this.enemies.getEnemiesInRange(
+        this.target.x,
+        this.target.y,
+        this.cfg.explosionRadius,
+      );
+      for (const e of victims) {
+        e.takeDamage(this.cfg.damage);
+        if (this.cfg.slowPct) e.addSlow?.(this.cfg.slowPct, this.cfg.slowDur!);
+      }
+    } else {
+      this.target.takeDamage(this.cfg.damage);
+      if (this.cfg.slowPct) this.target.addSlow?.(this.cfg.slowPct, this.cfg.slowDur!);
+    }
+    this.active = false;
+  }
+}
+
+export class ProjectilePool extends ObjectPool<Projectile> {
+  public active: Projectile[] = [];
+  constructor(manager: EnemyManager) {
+    super(
+      () => new Projectile(manager),
+      (p) => p.reset(),
+    );
+  }
+  acquire(): Projectile {
+    const p = super.acquire();
+    this.active.push(p);
+    return p;
+  }
+  release(p: Projectile) {
+    const idx = this.active.indexOf(p);
+    if (idx >= 0) this.active.splice(idx, 1);
+    super.release(p);
+  }
+}

--- a/src/entities/Tower.ts
+++ b/src/entities/Tower.ts
@@ -1,0 +1,42 @@
+import { EnemyManager } from './EnemyManager';
+import { ProjectilePool, ProjectileType } from './Projectile';
+
+export class Tower {
+  cooldown = 0;
+  x: number;
+  y: number;
+  type: ProjectileType;
+  range: number;
+  fireRate: number;
+  private enemies: EnemyManager;
+  private projectiles: ProjectilePool;
+
+  constructor(
+    x: number,
+    y: number,
+    type: ProjectileType,
+    range: number,
+    fireRate: number,
+    enemies: EnemyManager,
+    projectiles: ProjectilePool,
+  ) {
+    this.x = x;
+    this.y = y;
+    this.type = type;
+    this.range = range;
+    this.fireRate = fireRate;
+    this.enemies = enemies;
+    this.projectiles = projectiles;
+  }
+
+  update(dt: number) {
+    this.cooldown -= dt;
+    if (this.cooldown > 0) return;
+    const target = this.enemies.getMostAdvancedInRange(this.x, this.y, this.range);
+    if (target) {
+      const p = this.projectiles.acquire();
+      p.fire(this.type, this.x, this.y, target);
+      this.cooldown = 1 / this.fireRate;
+    }
+  }
+}

--- a/src/entities/projectile.test.ts
+++ b/src/entities/projectile.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { Enemy, EnemyManager } from './EnemyManager';
+import { ProjectilePool } from './Projectile';
+
+class DummyEnemy implements Enemy {
+  dead = false;
+  speed = 100;
+  baseSpeed = 100;
+  slowTime = 0;
+  x: number;
+  y: number;
+  progress: number;
+  constructor(x: number, y: number, progress: number) {
+    this.x = x;
+    this.y = y;
+    this.progress = progress;
+  }
+  takeDamage() {
+    this.dead = true;
+  }
+  addSlow(pct: number, dur: number) {
+    this.speed = this.baseSpeed * (1 - pct);
+    this.slowTime = dur;
+  }
+  update(dt: number) {
+    if (this.slowTime > 0) {
+      this.slowTime -= dt;
+      if (this.slowTime <= 0) {
+        this.speed = this.baseSpeed;
+      }
+    }
+  }
+}
+
+describe('frost projectile', () => {
+  it('applies slow that expires', () => {
+    const manager = new EnemyManager();
+    const enemy = new DummyEnemy(0, 0, 0.5);
+    manager.add(enemy);
+    const pool = new ProjectilePool(manager);
+    const p = pool.acquire();
+    p.fire('frost', 0, 0, enemy);
+    p.update(0.1);
+    expect(enemy.speed).toBeCloseTo(70);
+    enemy.update(1);
+    expect(enemy.speed).toBeCloseTo(70);
+    enemy.update(1.1);
+    expect(enemy.speed).toBeCloseTo(100);
+  });
+});

--- a/src/entities/tower.test.ts
+++ b/src/entities/tower.test.ts
@@ -1,24 +1,62 @@
 import { describe, it, expect } from 'vitest';
+import { Enemy, EnemyManager } from './EnemyManager';
+import { Tower } from './Tower';
+import { ProjectilePool } from './Projectile';
 
-class DummyTower {
-  fireRate = 1;
-  cooldown = 1;
-  shots = 0;
+class DummyEnemy implements Enemy {
+  dead = false;
+  speed = 100;
+  baseSpeed = 100;
+  slowTime = 0;
+  x: number;
+  y: number;
+  progress: number;
+  constructor(x: number, y: number, progress: number) {
+    this.x = x;
+    this.y = y;
+    this.progress = progress;
+  }
+  takeDamage() {
+    this.dead = true;
+  }
+  addSlow(pct: number, dur: number) {
+    this.speed = this.baseSpeed * (1 - pct);
+    this.slowTime = dur;
+  }
   update(dt: number) {
-    this.cooldown -= dt;
-    if (this.cooldown <= 0) {
-      this.shots += 1;
-      this.cooldown = 1 / this.fireRate;
+    if (this.slowTime > 0) {
+      this.slowTime -= dt;
+      if (this.slowTime <= 0) this.speed = this.baseSpeed;
     }
   }
 }
 
-describe('tower cooldown', () => {
+describe('tower shooting', () => {
   it('fires after cooldown expires', () => {
-    const t = new DummyTower();
-    t.update(0.5);
-    expect(t.shots).toBe(0);
-    t.update(0.6);
-    expect(t.shots).toBe(1);
+    const enemies = new EnemyManager();
+    const e = new DummyEnemy(2, 0, 0.1);
+    enemies.add(e);
+    const pool = new ProjectilePool(enemies);
+    const tower = new Tower(0, 0, 'arrow', 5, 1, enemies, pool);
+    tower.cooldown = 1;
+    tower.update(0.5);
+    expect(pool.active.length).toBe(0);
+    tower.update(0.6);
+    expect(pool.active.length).toBe(1);
+  });
+
+  it('retargets when target leaves range', () => {
+    const enemies = new EnemyManager();
+    const e1 = new DummyEnemy(3, 0, 0.6);
+    const e2 = new DummyEnemy(2, 0, 0.4);
+    enemies.add(e1);
+    enemies.add(e2);
+    const pool = new ProjectilePool(enemies);
+    const tower = new Tower(0, 0, 'arrow', 5, 1, enemies, pool);
+    tower.update(1);
+    expect(pool.active[0].target).toBe(e1);
+    e1.x = 100; // out of range
+    tower.update(1);
+    expect(pool.active[1].target).toBe(e2);
   });
 });


### PR DESCRIPTION
## Summary
- add enemy manager helper for range queries and advanced targeting
- implement tower cooldown with retargeting and projectile spawning
- create projectile system with arrow, cannon, and frost slow variants

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6898c4e0183c8322a972d2aa130d8b6f