### PR TITLE
feat: add distinct tower and UI sound effects

### DIFF
--- a/src/audio/SoundManager.ts
+++ b/src/audio/SoundManager.ts
@@ -1,4 +1,4 @@
-import { playTone } from './synth';
+import { playTone, playNoise } from './synth';
 
 export class SoundManager {
   private ctx: AudioContext | null =
@@ -23,34 +23,43 @@ export class SoundManager {
   getVolume() {
     return { master: this.master, sfx: this.sfx };
   }
-  private play(freq: number, dur: number, type: OscillatorType = 'sine') {
+  private play(freq: number, dur: number, type: OscillatorType = 'sine', vol = 0.3) {
     if (this.muted || !this.ctx) return;
-    playTone(this.ctx, freq, dur, type, this.master * this.sfx);
+    playTone(this.ctx, freq, dur, type, this.master * this.sfx * vol);
+  }
+  private noise(dur: number, vol = 0.3) {
+    if (this.muted || !this.ctx) return;
+    playNoise(this.ctx, dur, this.master * this.sfx * vol);
   }
   playShootArrow() {
-    this.play(880, 80, 'square');
+    // high pitched plink
+    this.play(1200, 60, 'square');
   }
   playShootCannon() {
-    this.play(200, 80, 'sine');
-    this.play(80, 120, 'sawtooth');
+    // short thud then booming low note
+    this.play(160, 80, 'sine');
+    this.play(80, 260, 'sawtooth');
   }
   playShootFrost() {
-    this.play(660, 100, 'triangle');
+    // crystalline tink with a subtle whoosh
+    this.play(1000, 80, 'triangle');
+    this.noise(200, 0.15);
   }
   playHit() {
-    this.play(220, 80, 'square');
+    this.play(300, 80, 'square');
   }
   playExplosion() {
-    this.play(120, 200, 'sawtooth');
+    this.noise(300, 0.4);
+    this.play(100, 300, 'sawtooth', 0.4);
   }
   playPlace() {
-    this.play(500, 50, 'square');
+    this.play(600, 50, 'square');
   }
   playError() {
-    this.play(100, 150, 'sawtooth');
+    this.play(90, 200, 'sawtooth');
   }
   playConfirm() {
-    this.play(660, 80, 'triangle');
+    this.play(700, 100, 'triangle');
   }
   playCash() {
     this.play(440, 120, 'square');

--- a/src/audio/synth.ts
+++ b/src/audio/synth.ts
@@ -4,6 +4,7 @@ export function playTone(
   dur: number,
   type: OscillatorType = 'sine',
   volume = 1,
+  fade = 0.07,
 ) {
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
@@ -13,8 +14,32 @@ export function playTone(
   osc.connect(gain);
   gain.connect(ctx.destination);
   const now = ctx.currentTime;
+  const end = now + dur / 1000;
+  const fadeStart = Math.max(now, end - fade);
   gain.gain.setValueAtTime(volume, now);
-  gain.gain.exponentialRampToValueAtTime(0.001, now + dur / 1000);
+  gain.gain.setValueAtTime(volume, fadeStart);
+  gain.gain.exponentialRampToValueAtTime(0.001, end);
   osc.start(now);
-  osc.stop(now + dur / 1000);
+  osc.stop(end);
+}
+
+export function playNoise(ctx: AudioContext, dur: number, volume = 1, fade = 0.07) {
+  const bufferSize = ctx.sampleRate * (dur / 1000);
+  const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufferSize; i++) data[i] = Math.random() * 2 - 1;
+  const noise = ctx.createBufferSource();
+  noise.buffer = buffer;
+  const gain = ctx.createGain();
+  gain.gain.value = volume;
+  noise.connect(gain);
+  gain.connect(ctx.destination);
+  const now = ctx.currentTime;
+  const end = now + dur / 1000;
+  const fadeStart = Math.max(now, end - fade);
+  gain.gain.setValueAtTime(volume, now);
+  gain.gain.setValueAtTime(volume, fadeStart);
+  gain.gain.exponentialRampToValueAtTime(0.001, end);
+  noise.start(now);
+  noise.stop(end);
 }


### PR DESCRIPTION
## Summary
- add fade-out and white-noise synthesis utilities
- give Arrow, Cannon, and Frost towers unique shooting sounds plus UI feedback for place/confirm/error

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898c9ce7b688322b4ad867b22000ea5