### PR TITLE
feat: expose editable grid path

### DIFF
--- a/src/systems/actions.test.ts
+++ b/src/systems/actions.test.ts
@@ -27,7 +27,7 @@ const sceneStub = {
 
 describe('placement controller', () => {
   it('releases cell on remove', () => {
-    const map = createGridMap(sceneStub, { cols: 6, rows: 6, tileSize: 32 });
+    const map = createGridMap(sceneStub, { cols: 20, rows: 12, tileSize: 32 });
     const pc = new PlacementController(map);
     const cell = { x: 1, y: 1 };
     expect(pc.place(cell)).toBe(true);
@@ -36,7 +36,7 @@ describe('placement controller', () => {
   });
 
   it('rejects placement on occupied cell', () => {
-    const map = createGridMap(sceneStub, { cols: 6, rows: 6, tileSize: 32 });
+    const map = createGridMap(sceneStub, { cols: 20, rows: 12, tileSize: 32 });
     const pc = new PlacementController(map);
     const cell = { x: 1, y: 1 };
     expect(pc.place(cell)).toBe(true);

--- a/src/systems/map.test.ts
+++ b/src/systems/map.test.ts
@@ -4,7 +4,7 @@ vi.mock('phaser', () => ({
   default: { Display: { Color: { HexStringToColor: () => ({ color: 0 }) } } },
 }));
 
-import { createGridMap, isBuildable, GridCell } from './map';
+import { createGridMap, isBuildable, GridCell, PATH_CELLS, validPath } from './map';
 
 const sceneStub = {
   add: {
@@ -32,5 +32,9 @@ describe('grid map buildable mask', () => {
     const inside: GridCell = { x: 6, y: 6 };
     expect(isBuildable(start, map)).toBe(false);
     expect(isBuildable(inside, map)).toBe(true);
+  });
+
+  it('has a contiguous path', () => {
+    expect(validPath(PATH_CELLS)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add helper to build grid-aligned path and export editable PATH_CELLS
- validate path contiguity with tests
- adjust placement tests to updated grid path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d07224a48322b00b183a87a2da93